### PR TITLE
KP-5802 Install psycopg2 version 2.7.1 instead of 2.7

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ git+https://github.com/metashare/django-selectable.git@d8381086e8307257259a6cedf
 django-selenium==0.9.7
 flup==1.0.3
 httplib2==0.9.1
-psycopg2==2.7
+psycopg2==2.7.1
 pycountry==1.12
 pygeoip==0.3.2
 pysolr==2.1.0-beta


### PR DESCRIPTION
Without the patch, installation on CentOS7 fails due to `XLogRecPtr` not being defined (see https://github.com/psycopg/psycopg2/issues/520). The 2.7.1 patch fixes this.